### PR TITLE
Separate sim communication channel

### DIFF
--- a/micropython/main.py
+++ b/micropython/main.py
@@ -24,6 +24,12 @@ cert_id = "ucrt"
 
 lte = LTE()
 
+if machine.reset_cause() != machine.DEEPSLEEP_RESET:
+    #if we are not coming from deepsleep, the modem is probably in a strange state -> reset
+    print("Not coming from sleep, resetting modem to be safe...")
+    lte.reset()
+    lte.init()
+
 if 'wifi' in cfg:
     nb_iot_connection = False
     func_lvl = 4  # disable modem transmit and receive RF circuits
@@ -79,7 +85,8 @@ try:
 except Exception as e:
     set_led(LED_RED)
     sys.print_exception(e)
-    lte_shutdown(lte)
+    ubirch.deinit()
+    lte_shutdown(lte)    
     reset()
 
 # get IMSI from SIM
@@ -98,6 +105,7 @@ else:
     except Exception as e:
         set_led(LED_ORANGE)
         sys.print_exception(e)
+        ubirch.deinit()
         lte_shutdown(lte)
         reset()
 
@@ -133,6 +141,7 @@ except Exception as e:
     except Exception as e:
         set_led(LED_ORANGE)
         sys.print_exception(e)
+        ubirch.deinit()
         lte_shutdown(lte)
         reset()
 
@@ -144,10 +153,10 @@ while True:
     # reinitialize LTE and reconnect to LTE network
     try:
         lte_setup(lte, nb_iot_connection, cfg.get("apn"))
-        ubirch.reinit(pin)
     except Exception as e:
         set_led(LED_PURPLE)
         sys.print_exception(e)
+        ubirch.deinit()
         lte_shutdown(lte)
         reset()
 
@@ -187,6 +196,7 @@ while True:
     except Exception as e:
         set_led(LED_PURPLE)
         sys.print_exception(e)
+        ubirch.deinit()
         lte_shutdown(lte)
         reset()
 

--- a/micropython/ubirch/ubirch_sim.py
+++ b/micropython/ubirch/ubirch_sim.py
@@ -156,6 +156,19 @@ class SimProtocol:
 
         self.lte.pppresume()
 
+    def deinit(self):
+        """
+        Deintializes the SIM interface. Used in preparation for events like low-power
+        sleep. Closes the APUD communication channel. Does not deinitialize/disconnect the LTE.
+        """
+        #Close logical channel to SIM if open
+        if self.channel != None:
+            if self.close_channel(self.channel):
+                self.channel = None
+            else:
+                raise Exception("Unable to close channel {}".format(self.channel))
+
+
     def _send_at_cmd(self, cmd):
         if self.DEBUG: print("++ " + cmd)
         result = [k for k in self.lte.send_at_cmd(cmd).split('\r\n') if len(k.strip()) > 0]
@@ -184,8 +197,8 @@ class SimProtocol:
     def close_channel(self,channel_to_close:int) -> bool:
         """
         Closes the specified logical channel to the SIM (see ISO 7816 part 4 sect. 6.16)
-        Throws an exception in case of failure. Always uses channel 0 (basic channel) for request.
-        Does not change the internal channel used by the class. Returns true if closing was successfull.
+        Always uses channel 0 (basic channel) for request. Does not change the internal
+        channel used by the class. Returns true if closing was successfull.
         """
         old_channel = self.channel # save lib channel
         self.channel = 0 #send on basic channel

--- a/micropython/ubirch/ubirch_sim.py
+++ b/micropython/ubirch/ubirch_sim.py
@@ -161,12 +161,15 @@ class SimProtocol:
         Deintializes the SIM interface. Used in preparation for events like low-power
         sleep. Closes the APUD communication channel. Does not deinitialize/disconnect the LTE.
         """
+        self.lte.pppsuspend()
         #Close logical channel to SIM if open
         if self.channel != None:
             if self.close_channel(self.channel):
                 self.channel = None
             else:
+                self.lte.pppresume()
                 raise Exception("Unable to close channel {}".format(self.channel))
+        self.lte.pppresume()
 
 
     def _send_at_cmd(self, cmd):

--- a/micropython/ubirch/ubirch_sim.py
+++ b/micropython/ubirch/ubirch_sim.py
@@ -128,8 +128,9 @@ class SimProtocol:
 
         The LTE functionality must be enabled upfront.
 
-        If there is already a channel to the SIM it can be specified with channel=X. If
-        not specified a new channel will be requested from the SIM and set automatically.
+        If there is already a channel to the SIM it can be specified with channel=X. Supported
+        channel values are 0-3. If not specified a new channel will be requested from the SIM
+        and set automatically.        
         """
         self.channel = channel
         self.lte = lte
@@ -179,6 +180,22 @@ class SimProtocol:
         if assigned_channel > 3 or assigned_channel < 0:
             raise Exception("unsupported channel number received")
         return assigned_channel
+
+    def close_channel(self,channel_to_close:int) -> bool:
+        """
+        Closes the specified logical channel to the SIM (see ISO 7816 part 4 sect. 6.16)
+        Throws an exception in case of failure. Always uses channel 0 (basic channel) for request.
+        Does not change the internal channel used by the class. Returns true if closing was successfull.
+        """
+        old_channel = self.channel # save lib channel
+        self.channel = 0 #send on basic channel
+        _,code = self._execute(STK_CLOSE_CHANNEL.format(channel_to_close))#send 
+        self.channel =old_channel # restore lib channel
+
+        if code == STK_OK :
+            return True
+        else:
+            return False
         
 
     def _execute(self, cmd: str) -> (bytes, str):

--- a/micropython/ubirch/ubirch_sim.py
+++ b/micropython/ubirch/ubirch_sim.py
@@ -146,7 +146,7 @@ class SimProtocol:
 
         #if no channel set: open a new communication channel to SIM and save it
         if self.channel == None:
-            self.channel = self.open_channel()
+            self.channel = self._open_channel()
         
         # select the SIGNiT application
         if self.DEBUG: print("\n>> selecting SIM application")
@@ -164,7 +164,7 @@ class SimProtocol:
         self.lte.pppsuspend()
         #Close logical channel to SIM if open
         if self.channel != None:
-            if self.close_channel(self.channel):
+            if self._close_channel(self.channel):
                 self.channel = None
             else:
                 self.lte.pppresume()
@@ -178,7 +178,7 @@ class SimProtocol:
         if self.DEBUG: print('-- ' + '\r\n-- '.join([r for r in result]))
         return result
 
-    def open_channel(self) -> (int):
+    def _open_channel(self) -> (int):
         """
         Open a new logical channel to communicate with the SIM (see ISO 7816 part 4 sect. 6.16)
         Throws an exception if the SIM does not assign a new channel succesfully. Returns assigned channel.
@@ -197,7 +197,7 @@ class SimProtocol:
             raise Exception("unsupported channel number received")
         return assigned_channel
 
-    def close_channel(self,channel_to_close:int) -> bool:
+    def _close_channel(self,channel_to_close:int) -> bool:
         """
         Closes the specified logical channel to the SIM (see ISO 7816 part 4 sect. 6.16)
         Always uses channel 0 (basic channel) for request. Does not change the internal

--- a/micropython/ubirch/ubirch_sim.py
+++ b/micropython/ubirch/ubirch_sim.py
@@ -121,14 +121,17 @@ def _decode_tag(encoded: bytes) -> [(int, bytes)]:
 class SimProtocol:
     MAX_AT_LENGTH = 110
 
-    def __init__(self, lte: LTE, at_debug: bool = False):
+    def __init__(self, lte: LTE, at_debug: bool = False, channel: int = None):
         """
         Initialize the SIM interface. This executes a command to initialize the modem,
         and waits for the modem to be ready, then selects the SIM application.
 
         The LTE functionality must be enabled upfront.
+
+        If there is already a channel to the SIM it can be specified with channel=X. If
+        not specified a new channel will be requested from the SIM and set automatically.
         """
-        self.channel = 1#TODO: Set to None on init
+        self.channel = channel
         self.lte = lte
         self.DEBUG = at_debug
         self.init()
@@ -140,6 +143,10 @@ class SimProtocol:
             self.lte.pppresume()
             raise Exception("couldn't access SIM")
 
+        #if no channel set: open a new communication channel to SIM and save it
+        if self.channel == None:
+            self.channel = self.open_channel()
+        
         # select the SIGNiT application
         if self.DEBUG: print("\n>> selecting SIM application")
         if not self._select_app():


### PR DESCRIPTION
Implements opening of a  separate communication channel to the SIM so as not to interfere with other communications between modem and SIM (UP-1887).